### PR TITLE
Update transport.go

### DIFF
--- a/blynk.go
+++ b/blynk.go
@@ -15,7 +15,7 @@ import (
 	slog "github.com/OloloevReal/go-simple-log"
 )
 
-const Version = "0.0.6"
+const Version = "0.0.7"
 
 type Blynk struct {
 	APIkey          string

--- a/blynk.go
+++ b/blynk.go
@@ -15,7 +15,7 @@ import (
 	slog "github.com/OloloevReal/go-simple-log"
 )
 
-const Version = "0.0.5"
+const Version = "0.0.6"
 
 type Blynk struct {
 	APIkey          string

--- a/transport.go
+++ b/transport.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"strconv"
+	"strings"
 	"time"
 
 	slog "github.com/OloloevReal/go-simple-log"

--- a/transport.go
+++ b/transport.go
@@ -177,8 +177,15 @@ func (g *Blynk) processor() {
 								slog.Printf("[DEBUG] failed to find reader, Pin: %d", pin)
 							} else {
 								var buf bytes.Buffer
-								buf.WriteString(resp.Values[2])
-								slog.Printf("[DEBUG] value: %s", resp.Values[2])
+								// buf.WriteString(resp.Values[2])
+								// slog.Printf("[DEBUG] value: %s", resp.Values[2])
+
+								// Join all values begins from index 2
+								// Now we can control merged zeRGBa with single pin
+								data := strings.Join(resp.Values[2:], ".")
+								slog.Printf("[DEBUG] value: %s", data)
+
+								buf.WriteString(data)
 								writer(uint(pin), &buf)
 							}
 						}


### PR DESCRIPTION
processor() modified
Now we can control merged zeRGBa with single pin 

type Color struct {
	red   int
	green int
	blue  int
}

app.AddWriterHandler(49, func(pin uint, reader io.Reader) {

		color := Color{}

		data, err := io.ReadAll(reader)
		if err != nil {
			fmt.Println("Error reading data:", err)
			return
		}

		dataStr := strings.TrimSpace(string(data))

		parts := strings.Split(dataStr, ".")
		if len(parts) != 3 {
			fmt.Printf("Unexpected data format. Expected 3 values, got %d: %v\n", len(parts), parts)
			return
		}

		red, err := strconv.Atoi(parts[0])
		if err != nil {
			fmt.Println("Error converting red value:", err)
			return
		}

		green, err := strconv.Atoi(parts[1])
		if err != nil {
			fmt.Println("Error converting green value:", err)
			return
		}

		blue, err := strconv.Atoi(parts[2])
		if err != nil {
			fmt.Println("Error converting blue value:", err)
			return
		}

		color.green = green
		color.red = red
		color.blue = blue

		setColor(color)
})